### PR TITLE
fix (libspell.lua): GetSpellInfo() now properly spots the spell-cast-time and range components in the spell tooltip

### DIFF
--- a/libs/libspell.lua
+++ b/libs/libspell.lua
@@ -115,9 +115,10 @@ function libspell.GetSpellInfo(index, bookType)
 
   if id then
     scanner:SetSpell(id, bookType)
-    local _, sec = scanner:Find(gsub(SPELL_CAST_TIME_SEC, "%%.3g", "%(.+%)"))
-    local _, min = scanner:Find(gsub(SPELL_CAST_TIME_MIN, "%%.3g", "%(.+%)"))
-    local _, range = scanner:Find(gsub(SPELL_RANGE, "%%s", "%(.+%)"))
+    local _, sec = scanner:Find(gsub(SPELL_CAST_TIME_SEC, "%%.3g", "%(.+%)"), false)
+    local _, min = scanner:Find(gsub(SPELL_CAST_TIME_MIN, "%%.3g", "%(.+%)"), false)
+    local _, range = scanner:Find(gsub(SPELL_RANGE, "%%s", "%(.+%)"), false)
+    
     castingTime = (tonumber(sec) or tonumber(min) or 0) * 1000
     if range then
       local _, _, min, max = string.find(range, "(.+)-(.+)")


### PR DESCRIPTION
To fix this bug we had to pass 'false' as the 2nd argument to scanner:Find() to disable "exact matching" in it.