### PR TITLE
dsidirop/6 consolidate getplayerbuff into an api method

### DIFF
--- a/api/unitframes.lua
+++ b/api/unitframes.lua
@@ -1556,11 +1556,11 @@ function pfUI.uf:RefreshUnit(unit, component)
       reposition = true
     end
 
-    local bid
+    local row, bid
     for i=1, unit.config.debufflimit do
       if not unit.debuffs[i] then break end
 
-      local row = floor((i-1) / unit.config.debuffperrow)
+      row = floor((i-1) / unit.config.debuffperrow)
 
       if reposition then
         unit.debuffs[i]:SetPoint(af, unit, unit.config.debuffs,

--- a/api/unitframes.lua
+++ b/api/unitframes.lua
@@ -1556,6 +1556,7 @@ function pfUI.uf:RefreshUnit(unit, component)
       reposition = true
     end
 
+    local bid
     for i=1, unit.config.debufflimit do
       if not unit.debuffs[i] then break end
 
@@ -1568,9 +1569,10 @@ function pfUI.uf:RefreshUnit(unit, component)
       end
 
       if unit.label == "player" then
-        texture = GetPlayerBuffTexture(pfUI.api.GetPlayerBuffX(i, "HARMFUL"))
-        stacks = GetPlayerBuffApplications(pfUI.api.GetPlayerBuffX(i, "HARMFUL"))
-        dtype = GetPlayerBuffDispelType(pfUI.api.GetPlayerBuffX(i, "HARMFUL"))
+        bid = pfUI.api.GetPlayerBuffX(i, "HARMFUL")
+        texture = GetPlayerBuffTexture(bid)
+        stacks = GetPlayerBuffApplications(bid)
+        dtype = GetPlayerBuffDispelType(bid)
       else
         texture, stacks, dtype = UnitDebuff(unitstr, i)
       end

--- a/api/unitframes.lua
+++ b/api/unitframes.lua
@@ -1489,14 +1489,15 @@ function pfUI.uf:RefreshUnit(unit, component)
 
   -- Buffs
   if unit.buffs and ( component == "all" or component == "aura" ) then
-    local texture, stacks
+    local texture, stacks, bid
 
     for i=1, unit.config.bufflimit do
       if not unit.buffs[i] then break end
 
       if unit.label == "player" then
-        stacks = GetPlayerBuffApplications(pfUI.api.GetPlayerBuffX(i,"HELPFUL"))
-        texture = GetPlayerBuffTexture(pfUI.api.GetPlayerBuffX(i,"HELPFUL"))
+        bid = pfUI.api.GetPlayerBuffX(i,"HELPFUL")
+        stacks = GetPlayerBuffApplications(bid)
+        texture = GetPlayerBuffTexture(bid)
       else
         texture, stacks = pfUI.uf:DetectBuff(unitstr, i)
       end

--- a/api/unitframes.lua
+++ b/api/unitframes.lua
@@ -121,7 +121,12 @@ local function BuffOnClick()
 end
 
 local function DebuffOnUpdate()
-  if ( this.tick or 1) > GetTime() then return else this.tick = GetTime() + .2 end
+  local now = GetTime()
+  if (this.tick or 1) > now then
+    return
+  end
+
+  this.tick = now + .2
   local timeleft = GetPlayerBuffTimeLeft(pfUI.api.GetPlayerBuffX(this.id,"HARMFUL"))
   local texture = GetPlayerBuffTexture(pfUI.api.GetPlayerBuffX(this.id,"HARMFUL"))
   local start = 0
@@ -132,7 +137,8 @@ local function DebuffOnUpdate()
     elseif maxdurations[texture] and maxdurations[texture] < timeleft then
       maxdurations[texture] = timeleft
     end
-    start = GetTime() + timeleft - maxdurations[texture]
+
+    start = now + timeleft - maxdurations[texture]
   end
 
   CooldownFrame_SetTimer(this.cd, start, maxdurations[texture], timeleft > 0 and 1 or 0)

--- a/api/unitframes.lua
+++ b/api/unitframes.lua
@@ -127,8 +127,9 @@ local function DebuffOnUpdate()
   end
 
   this.tick = now + .2
-  local timeleft = GetPlayerBuffTimeLeft(pfUI.api.GetPlayerBuffX(this.id,"HARMFUL"))
-  local texture = GetPlayerBuffTexture(pfUI.api.GetPlayerBuffX(this.id,"HARMFUL"))
+  local bid = pfUI.api.GetPlayerBuffX(this.id,"HARMFUL")
+  local timeleft = GetPlayerBuffTimeLeft(bid)
+  local texture = GetPlayerBuffTexture(bid)
   local start = 0
 
   if timeleft > 0 then

--- a/api/unitframes.lua
+++ b/api/unitframes.lua
@@ -27,7 +27,12 @@ local glow2 = {
 
 local maxdurations = {}
 local function BuffOnUpdate()
-  if ( this.tick or 1) > GetTime() then return else this.tick = GetTime() + .2 end
+  local now = GetTime()
+  if (this.tick or 1) > now then
+    return
+  end
+
+  this.tick = now + .2
   local timeleft = GetPlayerBuffTimeLeft(pfUI.api.GetPlayerBuffX(this.id,"HELPFUL"))
   local texture = GetPlayerBuffTexture(pfUI.api.GetPlayerBuffX(this.id,"HELPFUL"))
   local start = 0
@@ -38,7 +43,8 @@ local function BuffOnUpdate()
     elseif maxdurations[texture] and maxdurations[texture] < timeleft then
       maxdurations[texture] = timeleft
     end
-    start = GetTime() + timeleft - maxdurations[texture]
+
+    start = now + timeleft - maxdurations[texture]
   end
 
   CooldownFrame_SetTimer(this.cd, start, maxdurations[texture], timeleft > 0 and 1 or 0)

--- a/api/unitframes.lua
+++ b/api/unitframes.lua
@@ -33,8 +33,10 @@ local function BuffOnUpdate()
   end
 
   this.tick = now + .2
-  local timeleft = GetPlayerBuffTimeLeft(pfUI.api.GetPlayerBuffX(this.id,"HELPFUL"))
-  local texture = GetPlayerBuffTexture(pfUI.api.GetPlayerBuffX(this.id,"HELPFUL"))
+  
+  local bid = pfUI.api.GetPlayerBuffX(this.id,"HELPFUL")
+  local timeleft = GetPlayerBuffTimeLeft(bid)
+  local texture = GetPlayerBuffTexture(bid)
   local start = 0
 
   if timeleft > 0 then


### PR DESCRIPTION
- **docs (api.lua): trivial doc-comment tweaks**
- **perf (unitframes.lua): optimize BuffOnUpdate() a bit by avoiding to call GetTime() twice**
- **perf (unitframes.lua): BuffOnUpdate now calls pfUI.api.GetPlayerBuffX(this.id,"HELPFUL")**
- **perf (unitframes.lua): DebuffOnUpdate() now snapshots GetTime() once at the top of the call**
- **perf (unitframes.lua): DebuffOnUpdate() now calls GetPlayerBuffX() just once**
- **perf (unitframes.lua): call pfUI.api.GetPlayerBuffX(i,"HELPFUL") once in the 'buffs' section of :RefreshUnit()**
- **perf (unitframes.lua): call pfUI.api.GetPlayerBuffX(i,"HELPFUL") once per iteration inside the 'debuff' section of :RefreshUnit()**
- **perf (unitframes.lua): move the declaration of the 'row' variable outside the for-each-debuff loop of :RefreshUnit()**
