### PR TITLE
Libcast.lua: Optimize CastCustom()

### DIFF
--- a/libs/libcast.lua
+++ b/libs/libcast.lua
@@ -380,6 +380,7 @@ local function CastCustom(id, bookType, rawSpellName)
   for custom, func in pairs(libcast.customcast) do
     if strfind(rawSpellName, custom) ~= nil then
       func(true)
+      return
     end
   end
 end

--- a/libs/libcast.lua
+++ b/libs/libcast.lua
@@ -411,13 +411,18 @@ end, true)
 
 hooksecurefunc("UseAction", function(slot, target, button)
   scanner:SetAction(slot)
-  local spellName, rank = scanner:Line(1)
+  local rawSpellName, rank = scanner:Line(1)
+  if not rawSpellName then return end -- ignore if the spell is not found
+  
+  local cachedRawSpellName, cachedRank, cachedTexture, _, _, _, cachedSpellId, cachedBookType = libspell.GetSpellInfo(rawSpellName .. (rank and ("(" .. rank .. ")") or ""))
+  if not cachedRawSpellName or not cachedSpellId then return end -- ignore if the spell is not found
 
-  lastcasttex = GetActionTexture(slot)
-  lastrank = rank
+  lastrank = cachedRank
+  lastcasttex = cachedTexture
 
   if GetActionText(slot) or not IsCurrentAction(slot) then return end
-  CastCustom(spellName)
+
+  CastCustom(cachedSpellId, cachedBookType, cachedRawSpellName)
 end, true)
 
 -- add libcast to pfUI API

--- a/libs/libcast.lua
+++ b/libs/libcast.lua
@@ -374,13 +374,12 @@ libcast.customcast[strlower(multishot)] = function(begin, duration)
 end
 
 local function CastCustom(id, bookType, rawSpellName)
-  if not rawSpellName or GetSpellCooldown(id, bookType) == 0 then return end
-  
-  if not UnitCastingInfo(UnitName("player")) then
-    for custom, func in pairs(libcast.customcast) do
-      if strfind(strlower(rawSpellName), custom) or strlower(rawSpellName) == custom then
-        func(true)
-      end
+  if not rawSpellName or GetSpellCooldown(id, bookType) == 0 or UnitCastingInfo(player) then return end -- detect casting
+
+  rawSpellName = strlower(rawSpellName)
+  for custom, func in pairs(libcast.customcast) do
+    if strfind(rawSpellName, custom) or strlower(rawSpellName) == custom then
+      func(true)
     end
   end
 end

--- a/libs/libcast.lua
+++ b/libs/libcast.lua
@@ -375,14 +375,11 @@ end
 
 local function CastCustom(id, bookType, rawSpellName)
   if not rawSpellName or GetSpellCooldown(id, bookType) == 0 or UnitCastingInfo(player) then return end -- detect casting
+  
+  local func = libcast.customcast[strlower(rawSpellName)]
+  if not func then return end
 
-  rawSpellName = strlower(rawSpellName)
-  for custom, func in pairs(libcast.customcast) do
-    if strfind(rawSpellName, custom) ~= nil then
-      func(true)
-      return
-    end
-  end
+  func(true)  
 end
 
 hooksecurefunc("UseContainerItem", function(id, index)

--- a/libs/libcast.lua
+++ b/libs/libcast.lua
@@ -406,13 +406,7 @@ hooksecurefunc("CastSpellByName", function(spellCasted, target)
   lastrank = rank
   lastcasttex = texture
 
-  for i=1,120 do
-    -- detect if any cast is ongoing
-    if IsCurrentAction(i) then
-      CastCustom(cachedId, cachedBookType, rawSpellName)
-      return
-    end
-  end
+  CastCustom(cachedId, cachedBookType, rawSpellName)
 end, true)
 
 hooksecurefunc("UseAction", function(slot, target, button)

--- a/libs/libcast.lua
+++ b/libs/libcast.lua
@@ -373,11 +373,12 @@ libcast.customcast[strlower(multishot)] = function(begin, duration)
   end
 end
 
-local function CastCustom(spell)
-  if not spell then return end
+local function CastCustom(id, bookType, rawSpellName)
+  if not rawSpellName or GetSpellCooldown(id, bookType) == 0 then return end
+  
   if not UnitCastingInfo(UnitName("player")) then
     for custom, func in pairs(libcast.customcast) do
-      if strfind(strlower(spell), custom) or strlower(spell) == custom then
+      if strfind(strlower(rawSpellName), custom) or strlower(rawSpellName) == custom then
         func(true)
       end
     end
@@ -389,20 +390,18 @@ hooksecurefunc("UseContainerItem", function(id, index)
 end)
 
 hooksecurefunc("CastSpell", function(id, bookType)
-  local spellName, rank, texture, _, _, _, cachedId = libspell.GetSpellInfo(id, bookType)
-  if not spellName or not cachedId then return end -- ignore if the spell is not found
+  local rawSpellName, rank, texture, _, _, _, cachedId, cachedBookType = libspell.GetSpellInfo(id, bookType)
+  if not rawSpellName or not cachedId then return end -- ignore if the spell is not found
 
   lastrank = rank
   lastcasttex = texture
 
-  if GetSpellCooldown(id, bookType) ~= 0 then
-    CastCustom(spellName) 
-  end
+  CastCustom(cachedId, cachedBookType, rawSpellName)
 end, true)
 
 hooksecurefunc("CastSpellByName", function(spellCasted, target)
-  local spellName, rank, texture, _, _, _, cachedId = libspell.GetSpellInfo(spellCasted)
-  if not spellName or not cachedId then return end -- ignore if the spell is not found
+  local rawSpellName, rank, texture, _, _, _, cachedId, cachedBookType = libspell.GetSpellInfo(spellCasted)
+  if not rawSpellName or not cachedId then return end -- ignore if the spell is not found
 
   lastrank = rank
   lastcasttex = texture
@@ -410,7 +409,7 @@ hooksecurefunc("CastSpellByName", function(spellCasted, target)
   for i=1,120 do
     -- detect if any cast is ongoing
     if IsCurrentAction(i) then
-      CastCustom(spellCasted)
+      CastCustom(cachedId, cachedBookType, rawSpellName)
       return
     end
   end

--- a/libs/libcast.lua
+++ b/libs/libcast.lua
@@ -378,7 +378,7 @@ local function CastCustom(id, bookType, rawSpellName)
 
   rawSpellName = strlower(rawSpellName)
   for custom, func in pairs(libcast.customcast) do
-    if strfind(rawSpellName, custom) or strlower(rawSpellName) == custom then
+    if strfind(rawSpellName, custom) ~= nil then
       func(true)
     end
   end

--- a/libs/libcast.lua
+++ b/libs/libcast.lua
@@ -390,23 +390,23 @@ hooksecurefunc("UseContainerItem", function(id, index)
 end)
 
 hooksecurefunc("CastSpell", function(id, bookType)
-  local rawSpellName, rank, texture, _, _, _, cachedId, cachedBookType = libspell.GetSpellInfo(id, bookType)
-  if not rawSpellName or not cachedId then return end -- ignore if the spell is not found
+  local cachedRawSpellName, cachedRank, cachedTexture, _, _, _, cachedSpellId, cachedBookType = libspell.GetSpellInfo(id, bookType)
+  if not cachedRawSpellName or not cachedSpellId then return end -- ignore if the spell is not found
 
-  lastrank = rank
-  lastcasttex = texture
+  lastrank = cachedRank
+  lastcasttex = cachedTexture
 
-  CastCustom(cachedId, cachedBookType, rawSpellName)
+  CastCustom(cachedSpellId, cachedBookType, cachedRawSpellName)
 end, true)
 
 hooksecurefunc("CastSpellByName", function(spellCasted, target)
-  local rawSpellName, rank, texture, _, _, _, cachedId, cachedBookType = libspell.GetSpellInfo(spellCasted)
-  if not rawSpellName or not cachedId then return end -- ignore if the spell is not found
+  local cachedRawSpellName, cachedRank, cachedTexture, _, _, _, cachedSpellId, cachedBookType = libspell.GetSpellInfo(spellCasted)
+  if not cachedRawSpellName or not cachedSpellId then return end -- ignore if the spell is not found
 
-  lastrank = rank
-  lastcasttex = texture
+  lastrank = cachedRank
+  lastcasttex = cachedTexture
 
-  CastCustom(cachedId, cachedBookType, rawSpellName)
+  CastCustom(cachedSpellId, cachedBookType, cachedRawSpellName)
 end, true)
 
 hooksecurefunc("UseAction", function(slot, target, button)


### PR DESCRIPTION
- **refa (libcast.lua): move the GetSpellCooldown() check into CastCustom() and simplify the "CastSpell" check accordingly**
- **perf (libcast.lua): simplify and optimize the "CastSpellByName" post-hook**
- **perf (libcast.lua): cache strlower(rawSpellName)**
- **perf (libcast.lua): simplify the if-condition inside the for-loop into a single check**
- **perf (libcast.lua): we now break immediately after finding the first matching libcast.customcast entry**
- **libcast: reuse spellname and texture from previous call**
- **libcast: make post-hook update last cast texture**
- **fix (libcast.lua): adjust the "UseAction" post-hook to use the new flavour of CastCustom()**
- **refa (libcast.lua): trivial neutral renames for the sake clarity in the post-hooks of "CastSpell" and "CastSpellByName"**
- **perf (libcast.lua): CastCustom() has been optimized to simply use libcast.customcast as a mere lookup-table instead of iterating over all of its entries one by one**
